### PR TITLE
refactor: use ES modules for Hardhat scripts

### DIFF
--- a/smart_contracts/hardhat.config.js
+++ b/smart_contracts/hardhat.config.js
@@ -1,17 +1,19 @@
-require("dotenv").config();
-require("hardhat-contract-sizer");
-require("@nomiclabs/hardhat-etherscan");
-require("@nomicfoundation/hardhat-chai-matchers");
-require("@nomicfoundation/hardhat-ethers");
-require("hardhat-gas-reporter");
-require("solidity-coverage");
+import dotenv from "dotenv";
+import "hardhat-contract-sizer";
+import "@nomiclabs/hardhat-etherscan";
+import "@nomicfoundation/hardhat-chai-matchers";
+import "@nomicfoundation/hardhat-ethers";
+import "hardhat-gas-reporter";
+import "solidity-coverage";
+
+dotenv.config();
 
 const POLYGONSCAN_API_KEY = process.env.POLYGONSCAN_API_KEY;
 const POLYGON_RPC_URL = process.env.POLYGON_RPC_URL;
 const MUMBAI_RPC_URL = process.env.MUMBAI_RPC_URL;
 const MAINNET_FORK_RPC_URL = process.env.MAINNET_FORK_ALCHEMY_URL;
 
-module.exports = {
+const config = {
   solidity: {
     compilers: [
       {
@@ -64,3 +66,5 @@ module.exports = {
     timeout: 60000,
   },
 };
+
+export default config;

--- a/smart_contracts/scripts/deploy-all.js
+++ b/smart_contracts/scripts/deploy-all.js
@@ -1,13 +1,13 @@
-const hre = require("hardhat");
-const fs = require("fs");
-const fse = require("fs-extra");
-const { verify } = require("../utils/verify");
-const {
+import hre from "hardhat";
+import fs from "fs";
+import fse from "fs-extra";
+import { verify } from "../utils/verify.js";
+import {
   getAmountInWei,
   developmentChains,
   deployContract,
-} = require("../utils/helpers");
-const { debugLog } = require("../utils/debug");
+} from "../utils/helpers.js";
+import { debugLog } from "../utils/debug.js";
 
 async function main() {
   const deployNetwork = hre.network.name;

--- a/smart_contracts/scripts/deploy-ganache.js
+++ b/smart_contracts/scripts/deploy-ganache.js
@@ -1,8 +1,8 @@
-const hre = require("hardhat");
-const fs = require("fs");
-const fse = require("fs-extra");
-const { getAmountInWei, deployContract } = require("../utils/helpers");
-const { debugLog } = require("../utils/debug");
+import hre from "hardhat";
+import fs from "fs";
+import fse from "fs-extra";
+import { getAmountInWei, deployContract } from "../utils/helpers.js";
+import { debugLog } from "../utils/debug.js";
 
 async function main() {
   const deployNetwork = hre.network.name;

--- a/smart_contracts/utils/debug.js
+++ b/smart_contracts/utils/debug.js
@@ -1,4 +1,4 @@
-function debugLog(message, error) {
+export function debugLog(message, error) {
   if (process.env.DEBUG) {
     if (error) {
       console.error(`[DEBUG] ${message}`, error);
@@ -7,5 +7,3 @@ function debugLog(message, error) {
     }
   }
 }
-
-module.exports = { debugLog };

--- a/smart_contracts/utils/helpers.js
+++ b/smart_contracts/utils/helpers.js
@@ -1,16 +1,16 @@
-const { ethers } = require("hardhat");
+import { ethers } from "hardhat";
 
-const developmentChains = ["hardhat", "localhost", "ganache"];
+export const developmentChains = ["hardhat", "localhost", "ganache"];
 
-function getAmountInWei(amount) {
+export function getAmountInWei(amount) {
   return ethers.parseEther(amount.toString(), "ether");
 }
 
-function getAmountFromWei(amount) {
+export function getAmountFromWei(amount) {
   return Number(ethers.formatUnits(amount.toString(), "ether"));
 }
 
-async function resetTime() {
+export async function resetTime() {
   const now = Math.floor(new Date().getTime() / 1000);
   const blockNumber = await ethers.provider.getBlockNumber();
   const timestamp = (await ethers.provider.getBlock(blockNumber)).timestamp;
@@ -19,20 +19,20 @@ async function resetTime() {
   await ethers.provider.send("evm_mine");
 }
 
-async function moveTimeTo(target) {
+export async function moveTimeTo(target) {
   const now = Math.floor(new Date().getTime() / 1000);
   const delta = target - now;
   await ethers.provider.send("evm_increaseTime", [delta]);
   await ethers.provider.send("evm_mine");
 }
 
-async function deployContract(name, args) {
+export async function deployContract(name, args) {
   const contract = await ethers.deployContract(name, args);
   await contract.waitForDeployment();
   return contract;
 }
 
-async function mintERC20(account, erc20Address, amount) {
+export async function mintERC20(account, erc20Address, amount) {
   const erc20 = await ethers.getContractAt("IERC20Mock", erc20Address);
   const mint_tx = await erc20
     .connect(account)
@@ -40,14 +40,14 @@ async function mintERC20(account, erc20Address, amount) {
   await mint_tx.wait(1);
 }
 
-async function approveERC20(account, erc20Address, approvedAmount, spender) {
+export async function approveERC20(account, erc20Address, approvedAmount, spender) {
   const erc20 = await ethers.getContractAt("IERC20Mock", erc20Address);
 
   const tx = await erc20.connect(account).approve(spender, approvedAmount);
   await tx.wait(1);
 }
 
-async function mintNewNFT(nftContract, account) {
+export async function mintNewNFT(nftContract, account) {
   const mintFee = await nftContract.mintFee();
   const TEST_URI = "ipfs://test-nft-uri";
   await nftContract
@@ -55,7 +55,7 @@ async function mintNewNFT(nftContract, account) {
     .mintNFT(account.address, TEST_URI, { value: mintFee });
 }
 
-async function mintNewNFTWithRoyalty(nftContract, account, royaltyFee) {
+export async function mintNewNFTWithRoyalty(nftContract, account, royaltyFee) {
   const mintFee = await nftContract.mintFee();
   const TEST_URI = "ipfs://test-nft-uri";
   await nftContract
@@ -65,21 +65,7 @@ async function mintNewNFTWithRoyalty(nftContract, account, royaltyFee) {
     });
 }
 
-async function approveERC721(account, nftContract, tokenId, spender) {
+export async function approveERC721(account, nftContract, tokenId, spender) {
   const tx = await nftContract.connect(account).approve(spender, tokenId);
   await tx.wait(1);
 }
-
-module.exports = {
-  developmentChains,
-  getAmountFromWei,
-  getAmountInWei,
-  deployContract,
-  mintERC20,
-  approveERC20,
-  resetTime,
-  moveTimeTo,
-  mintNewNFT,
-  mintNewNFTWithRoyalty,
-  approveERC721,
-};

--- a/smart_contracts/utils/verify.js
+++ b/smart_contracts/utils/verify.js
@@ -3,9 +3,9 @@
     Runs the verify task
 */
 
-const { run } = require("hardhat");
+import { run } from "hardhat";
 
-const verify = async (contractAddress, args) => {
+export const verify = async (contractAddress, args) => {
   console.log("Verifying contract...");
   try {
     await run("verify:verify", {
@@ -19,8 +19,4 @@ const verify = async (contractAddress, args) => {
       console.log(e);
     }
   }
-};
-
-module.exports = {
-  verify,
 };


### PR DESCRIPTION
## Summary
- convert Hardhat config to ESM with default export
- update deployment scripts and utils to use `import`/`export`

## Testing
- `yarn deploy-ganache` *(fails: The locator that owns the path can't be found inside the dependency tree)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4f40bd04832f9b901e03702f5b20