### PR TITLE
Fix missing fs-extra dependency in smart contract deployment script

### DIFF
--- a/smart_contracts/.pnp.cjs
+++ b/smart_contracts/.pnp.cjs
@@ -36,6 +36,7 @@ const RAW_RUNTIME_STATE =
           ["chai", "npm:4.4.0"],\
           ["dotenv", "npm:16.3.1"],\
           ["ethers", "npm:5.8.0"],\
+          ["fs-extra", "npm:11.3.1"],\
           ["hardhat", "virtual:a33f4857c82e1a8b026ae9dfc0d545cb435986fd2f02be64ed658f608db404c2e76acf75192e62099adfc4a3cf412abab3fe0ac299e671975463d144ae3adcfd#npm:2.26.3"],\
           ["hardhat-contract-sizer", "virtual:a33f4857c82e1a8b026ae9dfc0d545cb435986fd2f02be64ed658f608db404c2e76acf75192e62099adfc4a3cf412abab3fe0ac299e671975463d144ae3adcfd#npm:2.10.1"],\
           ["hardhat-gas-reporter", "virtual:a33f4857c82e1a8b026ae9dfc0d545cb435986fd2f02be64ed658f608db404c2e76acf75192e62099adfc4a3cf412abab3fe0ac299e671975463d144ae3adcfd#npm:2.3.0"],\
@@ -1472,6 +1473,7 @@ const RAW_RUNTIME_STATE =
           ["chai", "npm:4.4.0"],\
           ["dotenv", "npm:16.3.1"],\
           ["ethers", "npm:5.8.0"],\
+          ["fs-extra", "npm:11.3.1"],\
           ["hardhat", "virtual:a33f4857c82e1a8b026ae9dfc0d545cb435986fd2f02be64ed658f608db404c2e76acf75192e62099adfc4a3cf412abab3fe0ac299e671975463d144ae3adcfd#npm:2.26.3"],\
           ["hardhat-contract-sizer", "virtual:a33f4857c82e1a8b026ae9dfc0d545cb435986fd2f02be64ed658f608db404c2e76acf75192e62099adfc4a3cf412abab3fe0ac299e671975463d144ae3adcfd#npm:2.10.1"],\
           ["hardhat-gas-reporter", "virtual:a33f4857c82e1a8b026ae9dfc0d545cb435986fd2f02be64ed658f608db404c2e76acf75192e62099adfc4a3cf412abab3fe0ac299e671975463d144ae3adcfd#npm:2.3.0"],\
@@ -2889,6 +2891,16 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["fs-extra", [\
+      ["npm:11.3.1", {\
+        "packageLocation": "../../../root/.yarn/berry/cache/fs-extra-npm-11.3.1-4fd46d4895-10c0.zip/node_modules/fs-extra/",\
+        "packageDependencies": [\
+          ["fs-extra", "npm:11.3.1"],\
+          ["graceful-fs", "npm:4.2.11"],\
+          ["jsonfile", "npm:6.2.0"],\
+          ["universalify", "npm:2.0.1"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["npm:7.0.1", {\
         "packageLocation": "../../../root/.yarn/berry/cache/fs-extra-npm-7.0.1-b33a5e53e9-10c0.zip/node_modules/fs-extra/",\
         "packageDependencies": [\
@@ -3732,6 +3744,15 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["graceful-fs", "npm:4.2.10"],\
           ["jsonfile", "npm:4.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:6.2.0", {\
+        "packageLocation": "../../../root/.yarn/berry/cache/jsonfile-npm-6.2.0-aefb9ffd45-10c0.zip/node_modules/jsonfile/",\
+        "packageDependencies": [\
+          ["graceful-fs", "npm:4.2.10"],\
+          ["jsonfile", "npm:6.2.0"],\
+          ["universalify", "npm:2.0.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -5352,6 +5373,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../../../root/.yarn/berry/cache/universalify-npm-0.1.2-9b22d31d2d-10c0.zip/node_modules/universalify/",\
         "packageDependencies": [\
           ["universalify", "npm:0.1.2"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:2.0.1", {\
+        "packageLocation": "../../../root/.yarn/berry/cache/universalify-npm-2.0.1-040ba5a21e-10c0.zip/node_modules/universalify/",\
+        "packageDependencies": [\
+          ["universalify", "npm:2.0.1"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/smart_contracts/package.json
+++ b/smart_contracts/package.json
@@ -17,6 +17,7 @@
     "@openzeppelin/contracts": "^4.9.2",
     "chai": "^4.3.10",
     "ethers": "^5.7.2",
+    "fs-extra": "^11.3.1",
     "hardhat": "^2.22.5",
     "hardhat-contract-sizer": "^2.10.1"
   },

--- a/smart_contracts/yarn.lock
+++ b/smart_contracts/yarn.lock
@@ -1310,6 +1310,7 @@ __metadata:
     chai: "npm:^4.3.10"
     dotenv: "npm:^16.3.1"
     ethers: "npm:^5.7.2"
+    fs-extra: "npm:^11.3.1"
     hardhat: "npm:^2.22.5"
     hardhat-contract-sizer: "npm:^2.10.1"
     hardhat-gas-reporter: "npm:^2.3.0"
@@ -2513,6 +2514,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs-extra@npm:^11.3.1":
+  version: 11.3.1
+  resolution: "fs-extra@npm:11.3.1"
+  dependencies:
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^6.0.1"
+    universalify: "npm:^2.0.0"
+  checksum: 10c0/61e5b7285b1ca72c68dfe1058b2514294a922683afac2a80aa90540f9bd85370763d675e3b408ef500077d355956fece3bd24b546790e261c3d3015967e2b2d9
+  languageName: node
+  linkType: hard
+
 "fs-extra@npm:^7.0.1":
   version: 7.0.1
   resolution: "fs-extra@npm:7.0.1"
@@ -3266,6 +3278,19 @@ __metadata:
     graceful-fs:
       optional: true
   checksum: 10c0/7dc94b628d57a66b71fb1b79510d460d662eb975b5f876d723f81549c2e9cd316d58a2ddf742b2b93a4fa6b17b2accaf1a738a0e2ea114bdfb13a32e5377e480
+  languageName: node
+  linkType: hard
+
+"jsonfile@npm:^6.0.1":
+  version: 6.2.0
+  resolution: "jsonfile@npm:6.2.0"
+  dependencies:
+    graceful-fs: "npm:^4.1.6"
+    universalify: "npm:^2.0.0"
+  dependenciesMeta:
+    graceful-fs:
+      optional: true
+  checksum: 10c0/7f4f43b08d1869ded8a6822213d13ae3b99d651151d77efd1557ced0889c466296a7d9684e397bd126acf5eb2cfcb605808c3e681d0fdccd2fe5a04b47e76c0d
   languageName: node
   linkType: hard
 
@@ -4750,6 +4775,13 @@ __metadata:
   version: 0.1.2
   resolution: "universalify@npm:0.1.2"
   checksum: 10c0/e70e0339f6b36f34c9816f6bf9662372bd241714dc77508d231d08386d94f2c4aa1ba1318614f92015f40d45aae1b9075cd30bd490efbe39387b60a76ca3f045
+  languageName: node
+  linkType: hard
+
+"universalify@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "universalify@npm:2.0.1"
+  checksum: 10c0/73e8ee3809041ca8b818efb141801a1004e3fc0002727f1531f4de613ea281b494a40909596dae4a042a4fb6cd385af5d4db2e137b1362e0e91384b828effd3a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add fs-extra dependency to smart_contracts package
- regenerate yarn lockfile and PnP config

## Testing
- `yarn deploy-ganache` *(fails: HH108 Cannot connect to the network ganache)*

------
https://chatgpt.com/codex/tasks/task_e_68ae625c87c0832fa7d95fc01fee2da7