### PR TITLE
Replace fs-extra with native fs in deployment scripts

### DIFF
--- a/smart_contracts/scripts/deploy-all.js
+++ b/smart_contracts/scripts/deploy-all.js
@@ -1,6 +1,5 @@
 const hre = require("hardhat");
 const fs = require("fs");
-const fse = require("fs-extra");
 const { verify } = require("../utils/verify");
 const {
   getAmountInWei,
@@ -42,7 +41,9 @@ async function main() {
   /* transfer contracts addresses & ABIs to the front-end */
   if (fs.existsSync("../front-end/src")) {
     fs.rmSync("../src/artifacts", { recursive: true, force: true });
-    fse.copySync("./artifacts/contracts", "../front-end/src/artifacts");
+    fs.cpSync("./artifacts/contracts", "../front-end/src/artifacts", {
+      recursive: true,
+    });
     fs.writeFileSync(
       "../front-end/src/utils/contracts-config.js",
       `

--- a/smart_contracts/scripts/deploy-ganache.js
+++ b/smart_contracts/scripts/deploy-ganache.js
@@ -1,6 +1,5 @@
 const hre = require("hardhat");
 const fs = require("fs");
-const fse = require("fs-extra");
 const { getAmountInWei, deployContract } = require("../utils/helpers");
 const { debugLog } = require("../utils/debug");
 
@@ -44,7 +43,9 @@ async function main() {
   /* transfer contracts addresses & ABIs to the front-end */
   if (fs.existsSync("../front-end/src")) {
     fs.rmSync("../src/artifacts", { recursive: true, force: true });
-    fse.copySync("./artifacts/contracts", "../front-end/src/artifacts");
+    fs.cpSync("./artifacts/contracts", "../front-end/src/artifacts", {
+      recursive: true,
+    });
     fs.writeFileSync(
       "../front-end/src/utils/contracts-config.js",
       `


### PR DESCRIPTION
## Summary
- use Node's fs.cpSync in deploy scripts instead of fs-extra
- drop fs-extra dependency and refresh yarn lock/pnp manifest

## Testing
- `yarn deploy-ganache` *(fails: HH108 Cannot connect to the network ganache)*
- `yarn test` *(fails: 100 passing, 19 failing)*

------
https://chatgpt.com/codex/tasks/task_e_68ae625c87c0832fa7d95fc01fee2da7